### PR TITLE
Fix 2 minor glitches:

### DIFF
--- a/assets/css/lanyon.css
+++ b/assets/css/lanyon.css
@@ -297,6 +297,7 @@ a.sidebar-nav-item:focus {
  * page is wrapped in `.page` and is only used on the page layout.
  */
 
+.h-entry,
 .page,
 .post {
   margin-bottom: 4em;
@@ -392,7 +393,7 @@ a.pagination-item:hover {
     border-bottom-left-radius: 4px;
   }
   .pagination-item:last-child {
-    margin-left: -1px;
+    margin-left: 0;
     border-top-right-radius:    4px;
     border-bottom-right-radius: 4px;
   }


### PR DESCRIPTION
- Posts are know separated by a large space, like the original Lanyon theme
- Display entierly the previous and next post button when they are not displayed together
